### PR TITLE
ENManagerのActivateにLockを追加

### DIFF
--- a/Chino.iOS/ExposureNotificationClient.cs
+++ b/Chino.iOS/ExposureNotificationClient.cs
@@ -45,8 +45,11 @@ namespace Chino.iOS
 
         private bool IsActivated = false;
 
+        private readonly SemaphoreSlim ActivateSemaphore = new SemaphoreSlim(1, 1);
+
         public async Task ActivateAsync()
         {
+            await ActivateSemaphore.WaitAsync();
             if (IsActivated)
             {
                 return;
@@ -64,6 +67,10 @@ namespace Chino.iOS
                     throw exception.ToENException();
                 }
                 throw exception;
+            }
+            finally
+            {
+                ActivateSemaphore.Release();
             }
         }
 


### PR DESCRIPTION
COCOA2でiOSアプリで起動時に何回かに一度クラッシュしているようでした。
EnManager.activateが連続して呼ばれているのでdata raceが起きているようでした。
ActivateAsyncの処理の前後に排他制御を入れました。