### PR TITLE
例外の再スロー時に stack trace が消えてしまう問題を修正

### DIFF
--- a/Chino.Android/ExposureNotificationClient.cs
+++ b/Chino.Android/ExposureNotificationClient.cs
@@ -62,7 +62,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -96,7 +96,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -119,7 +119,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -142,7 +142,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -165,7 +165,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -189,7 +189,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -302,7 +302,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -326,7 +326,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -406,7 +406,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -430,7 +430,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -495,7 +495,7 @@ namespace Chino.Android.Google
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
             finally
             {

--- a/Chino.Android/ExposureStateBroadcastReceiver.cs
+++ b/Chino.Android/ExposureStateBroadcastReceiver.cs
@@ -195,7 +195,7 @@ namespace Chino.Android.Google
                         else
                         {
                             handler.ExceptionOccurred(exception);
-                            throw exception;
+                            throw;
                         }
                     }
                     finally
@@ -307,7 +307,7 @@ namespace Chino.Android.Google
                         else
                         {
                             handler.ExceptionOccurred(exception);
-                            throw exception;
+                            throw;
                         }
                     }
                     finally

--- a/Chino.iOS/ExposureNotificationClient.cs
+++ b/Chino.iOS/ExposureNotificationClient.cs
@@ -66,7 +66,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
             finally
             {
@@ -108,7 +108,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -126,7 +126,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -144,7 +144,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -171,7 +171,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -198,7 +198,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -358,7 +358,7 @@ namespace Chino.iOS
                 else
                 {
                     Handler.ExceptionOccurred(exception);
-                    throw exception;
+                    throw;
                 }
             }
             finally
@@ -452,7 +452,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
 
@@ -476,7 +476,7 @@ namespace Chino.iOS
                 {
                     throw exception.ToENException();
                 }
-                throw exception;
+                throw;
             }
         }
     }


### PR DESCRIPTION
C# の例外処理の `catch` 句で例外を再スローする場合は `throw exception;` ではなく単純に `throw;` と記載します。
`throw exception;` をすると例外のスタック トレースが、この行からになってしまい元々例外が発生した場所のスタック トレースが消えてしまいます。

https://docs.microsoft.com/ja-jp/dotnet/fundamentals/code-analysis/quality-rules/ca2200