### PR TITLE
Make PlatformType public.

### DIFF
--- a/Chino.Common/PlatformType.cs
+++ b/Chino.Common/PlatformType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Chino
 {
-    internal enum PlatformType
+    public enum PlatformType
     {
         Android = 1 << 7,
         iOS = 1 << 8


### PR DESCRIPTION
エラーコードがAndroid, iOSどちらのものか、PlatformTypeの各プラットフォーム毎のビットを使って判別しようとしていたけど、publicじゃなくてCOCOAから使えなかったのでpublicにする。